### PR TITLE
Update Dockerfile

### DIFF
--- a/2x/Dockerfile
+++ b/2x/Dockerfile
@@ -28,7 +28,7 @@ RUN docker-php-ext-install \
     \
     pecl install \
         libsodium-1.0.6 \
-        xdebug && \
+        xdebug-2.5.5 && \
     \
     echo "zend_extension=xdebug.so" > "$(php-config --prefix)/etc/php/conf.d/xdebug.ini" && \
     echo "extension=libsodium.so" > "$(php-config --prefix)/etc/php/conf.d/libsodium.ini"


### PR DESCRIPTION
pecl will install latest if you don't give a version and the latest version of xdebug doesn't work with php 5.6

2.5.5 is the last version to work with php 5.6 it looks like from xdebug download page.